### PR TITLE
Improve check of services, Fix #19

### DIFF
--- a/www/include/checkOnline.php
+++ b/www/include/checkOnline.php
@@ -1,0 +1,26 @@
+<?php
+
+$ALLOWED_PROTOCOLS = CURLPROTO_HTTP | CURLPROTO_HTTPS;
+$TIMEOUT = 10;
+
+if (!empty($_POST['url'])) {
+        $url = $_POST['url'];
+
+        $request = curl_init($url);
+
+	curl_setopt($request, CURLOPT_PROTOCOLS, $ALLOWED_PROTOCOLS);
+        curl_setopt($request, CURLOPT_CONNECTTIMEOUT, $TIMEOUT);
+        curl_setopt($request, CURLOPT_FOLLOWLOCATION, true);
+
+        $response = curl_exec($request);
+
+        if ($response)
+                $status_code = curl_getinfo($request, CURLINFO_HTTP_CODE);
+        else
+                $status_code = 502;
+
+        curl_close($request);
+
+        http_response_code($status_code);
+}
+?>

--- a/www/include/worker.js
+++ b/www/include/worker.js
@@ -178,14 +178,14 @@ function createSections() {
 async function checkOnline(thisUrl, thisId) {
 	//reads all tiles from settings and sets their respective indicators to green
 	const options = {
-		method: 'GET',
-		mode: 'no-cors',
-		connection: 'close'
+		method: 'POST',
+		body: new URLSearchParams({
+			url: thisUrl
+		})
 	};
 
-
-	const response = await fetch(thisUrl,options);
-	if (response.status = 200) {
+	const response = await fetch('include/checkOnline.php', options);
+	if (response.ok) {
 		thisId.className = thisId.className.replace(/dot(?!\S)/g, 'dot dot-green');
 		
 		//this theming needs to be done here because js can't change style of future elements of a class


### PR DESCRIPTION
Check of services is now handled by the host using a small PHP script that receives the URL to connect to and checks not only if it is alive, but also checks its status code or returns 502 as fallback. Check the status code is necessary in many cases, especially related to the container world, since the status code can be used to see if a service is really alive or dead (playing with healthcheckers and small services that perform this task, for example).

The checkOnline() function in worker.js has been modified a bit for reuse. I think another approach to implement this feature is to send an identifier to the PHP script that does a read to settings.json to get the URL of the website to check. I think this is a bit more complex, but it only makes sense if the settings.json cannot be modified through the web UI.

---

* This function requires the cURL extension.
* I was motivated to implement this feature when I deployed rest-server on my FreeBSD server. rest-server listens like any web application, the problem is when you send a request (GET) as it returns a number other than 200-299, so I used a healthchecker that checks if rest-server is alive by checking the `service restserver status` status code (and other checks) and writing to a small file that another container with a PHP script could read to change the status code returned. Such a container is called `health` and is just an apache server with PHP support, so the entry point is `http://health`, I use `http://health/rest-server/` in settings.json to check the status code. This sounds a bit complex, but it is very simple, but Dasherr requires interpreting the status code to actually tell me if the service is generating an error or not. See this [issue](https://github.com/restic/rest-server/issues/147) for more details on what I mention.