### PR TITLE
Svg stylings

### DIFF
--- a/www/include/theming.js
+++ b/www/include/theming.js
@@ -10,4 +10,19 @@ function applyTheme() {
 	$('.tile').css("color", currTheme.colorPr);
 	$('.iconButton').css("color", currTheme.colorPr);
 	$('.widget').css("color", currTheme.colorPr);
+
+	let iconObjs = document.querySelectorAll('object[id^="iconObj"]');
+	iconObjs.forEach(function(iconObj) {
+		iconObj.addEventListener('load', function() {
+		let svgDoc = iconObj.contentDocument;
+		if (svgDoc) {
+			let svgElements = svgDoc.querySelectorAll('*');
+			svgElements.forEach(function(element) {
+			if (element.tagName === 'path' || element.tagName === 'circle' || element.tagName === 'rect') {
+				element.setAttribute('fill', currTheme.colorPr);
+			}
+			});
+		}
+		});
+	});
 }

--- a/www/include/worker.js
+++ b/www/include/worker.js
@@ -169,6 +169,17 @@ function createSections() {
 				
 				tileLink.appendChild(tileIcon);
 			}
+			else if (gSettings.sections[n1].tiles[n2].svg) {
+
+				let tileIcon = document.createElement('object');
+				tileIcon.id = 'iconObj' + thisSec + thisTile;
+				tileIcon.data = gSettings.sections[n1].tiles[n2].svg;
+				tileIcon.width = 15;
+				tileIcon.className = gSettings.sections[n1].tiles[n2].svg;			
+				tileIcon.style = 'margin-right: 5px;';
+				
+				tileLink.appendChild(tileIcon);
+			}
 
 			tileLink.innerHTML = tileLink.innerHTML + thisTile;
 		}


### PR DESCRIPTION
Besides "faIcon" and "icon" a tile can now also use "svg". The specified svg-image will be loaded as an object and automatically assigend with colorPr.
This was only tested under my own circumstances with few different icons.