### PR TITLE
Feat: Add new pfSense and Proxmox dashboard widgets

### DIFF
--- a/www/include/checkOnline.php
+++ b/www/include/checkOnline.php
@@ -1,0 +1,26 @@
+<?php
+
+$ALLOWED_PROTOCOLS = CURLPROTO_HTTP | CURLPROTO_HTTPS;
+$TIMEOUT = 10;
+
+if (!empty($_POST['url'])) {
+        $url = $_POST['url'];
+
+        $request = curl_init($url);
+
+	curl_setopt($request, CURLOPT_PROTOCOLS, $ALLOWED_PROTOCOLS);
+        curl_setopt($request, CURLOPT_CONNECTTIMEOUT, $TIMEOUT);
+        curl_setopt($request, CURLOPT_FOLLOWLOCATION, true);
+
+        $response = curl_exec($request);
+
+        if ($response)
+                $status_code = curl_getinfo($request, CURLINFO_HTTP_CODE);
+        else
+                $status_code = 502;
+
+        curl_close($request);
+
+        http_response_code($status_code);
+}
+?>

--- a/www/include/pfsense-widget.php
+++ b/www/include/pfsense-widget.php
@@ -1,0 +1,46 @@
+<?php
+header('Content-Type: application/json');
+
+$requestBody = file_get_contents("php://input");
+$data = json_decode($requestBody, true);
+
+// Check if required parameters are provided
+if (!isset($data['url'], $data['xapikey'])) {
+    echo json_encode(["error" => "Missing required parameters"]);
+    http_response_code(400);
+    exit;
+}
+
+$url = rtrim($data['url'], '/');
+$xapikey = $data['xapikey'];
+
+// pfSense API endpoints
+$endpoints = [
+    "interfaceStatus" => "$url/api/v2/status/interfaces?limit=0&offset=0",
+    "dns" => "$url/api/v2/system/dns"
+];
+
+$results = [];
+
+// Fetch data from each endpoint
+foreach ($endpoints as $key => $apiUrl) {
+    $ch = curl_init($apiUrl);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        "x-api-key: $xapikey",
+        "Content-Type: application/json"
+    ]);
+
+    $response = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $error = curl_error($ch);
+    curl_close($ch);
+
+    if ($httpCode == 200) {
+        $results[$key] = json_decode($response, true)['data'] ?? ["error" => "Invalid JSON response"];
+    } else {
+        $results[$key] = ["error" => "Failed to fetch $key (HTTP $httpCode, $error)"];
+    }
+}
+
+echo json_encode($results, JSON_PRETTY_PRINT);

--- a/www/include/proxmox-widget.php
+++ b/www/include/proxmox-widget.php
@@ -1,0 +1,51 @@
+<?php
+header("Content-Type: application/json");
+
+// Get input JSON from POST request
+$requestBody = file_get_contents("php://input");
+$data = json_decode($requestBody, true);
+
+// Check if required parameters are provided
+if (!isset($data['url'], $data['token'], $data['node'])) {
+    echo json_encode(["error" => "Missing required parameters"]);
+    http_response_code(400);
+    exit;
+}
+
+$url = rtrim($data['url'], '/');
+$token = $data['token'];
+$node = $data['node'];
+
+// Proxmox API endpoints
+$endpoints = [
+    "node" => "$url/api2/json/nodes/$node/status",
+    "qemu" => "$url/api2/json/nodes/$node/qemu",
+    "lxc" => "$url/api2/json/nodes/$node/lxc",
+    "storage" => "$url/api2/json/nodes/$node/storage"
+];
+
+$results = [];
+
+// Fetch data from each endpoint
+foreach ($endpoints as $key => $apiUrl) {
+    $ch = curl_init($apiUrl);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        "Authorization: PVEAPIToken=$token",
+        "Content-Type: application/json"
+    ]);
+
+    $response = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $error = curl_error($ch);
+    curl_close($ch);
+
+    if ($httpCode == 200) {
+        $results[$key] = json_decode($response, true)['data'] ?? ["error" => "Invalid JSON response"];
+    } else {
+        $results[$key] = ["error" => "Failed to fetch $key (HTTP $httpCode, $error)"];
+    }
+}
+
+echo json_encode($results, JSON_PRETTY_PRINT);
+?>

--- a/www/index.php
+++ b/www/index.php
@@ -44,7 +44,7 @@
 		</div>
 		
 		<!-- Widgets get added here -->
-		<div id="areaWidgets" class="row row-cols-3 row-cols-sm-4 row-cols-md-6 row-cols-lg-10 row-cols-xl-12 gy-5" style="display:none">
+		<div id="areaWidgets" class="row row-cols-1 row-cols-sm-1 row-cols-md-1 row-cols-lg-2 row-cols-xl-2" style="display:none">
 		</div>
 	
 		<br>
@@ -55,7 +55,6 @@
 			
 		<!-- End Dashboard Contents -->
 	</div>
-
 
 	<!-- End Window Contents -->
   </body>

--- a/www/settings.sample.json
+++ b/www/settings.sample.json
@@ -7,10 +7,33 @@
 	"widgets": [
 		{
 			"disable": 0,
+			"name": "Dasher VM",
 			"type": "glances",
 			"settings": {
 				"url": "http://homeserver:61208/",
 				"refreshMs": 5000
+			}
+		},
+		{
+			"disable": 0,
+			"name": "PVE",
+			"type": "proxmox",
+			"settings": {
+				"url": "https://homeserver:8006",
+				"refreshMs": 31000,
+				"node": "pve",
+				"token": "user@realm!tokenname=token" // Privileges: Sys.Audit, Pool.Audit, VM.Audit, Datastore.Audit
+			}
+		}
+		,
+		{
+			"disable": 0,
+			"name": "pfSense",
+			"type": "pfsense", // requires https://github.com/jaredhendrickson13/pfsense-api
+			"settings": {
+				"url": "https://homeserver:443",
+				"refreshMs": 35000,
+				"xapikey": "***"
 			}
 		}
 	],


### PR DESCRIPTION
Since I don't use Glances I've allowed myself to enrich this project for myself by widgets for Proxmox and pfSense.

Proxmox:
- Shows CPU/RAM for a node and (uncollapsible) every VM/CT of this node
- Shows storage usage of this node and (uncollapsible) each storage pool
- Requires API-token

pfSense:
- Shows WAN-IP, status and bandwidth
- Shows PING to configured DNS
- Requires inofficial pfSense-API

As far as I'm concerned all values (list of VMs/CTs/storage-pools, interface-id of WAN, DNS-server) are fetched dynamically.

I also had to change the layout and the structure of widget-functions a little, but it seems to still work with more than 3 widgets and keeps the basic logic of the project.
Last thing I implemented the "check-online"-functionality from DtxdF https://github.com/erohtar/Dasherr/pull/23

Feel free to ask any questins about usage.
![widgets](https://github.com/user-attachments/assets/426c28a0-a675-47ad-92fb-9fc8a1f1e0e0)
![widgets_uncollapsed](https://github.com/user-attachments/assets/0daae6c9-f766-44fa-9728-2dff4acdc7b7)
